### PR TITLE
Ability to calculate power spectrum back from the grid

### DIFF
--- a/randomfield/powertools.py
+++ b/randomfield/powertools.py
@@ -24,7 +24,11 @@ def get_k_bounds(data, spacing, packed=True):
     return k_min, k_max
 
 
-def create_ksq_grids(data, spacing, packed):
+def create_ksq_grids(data, spacing, packed, meshgrid=True):
+    """
+    Returns k^2 fields for three coordinates, either mesgridded
+    or not
+    """
     nx, ny, nz = transform.expanded_shape(data, packed=packed)
     lambda0 = spacing / (2 * np.pi)
     kx = np.fft.fftfreq(nx, lambda0)
@@ -34,7 +38,10 @@ def create_ksq_grids(data, spacing, packed):
         kz = kz[:nz//2 + 1]
     # With the sparse option, the memory usage of these grids is
     # O(nx+ny+nz) rather than O(nx*ny*nz).
-    return np.meshgrid(kx**2, ky**2, kz**2, sparse=True, indexing='ij')
+    if (meshgrid):
+        return np.meshgrid(kx**2, ky**2, kz**2, sparse=True, indexing='ij')
+    else:
+        return kx**2, ky**2, kz**2
 
 
 def fill_with_log10k(data, spacing, packed=True):


### PR DESCRIPTION
... in order to eventually test sampling into point objects directly in the box.

This code snippet demonstrates it works:

```
#!/usr/bin/env python
import sys
import pylab
sys.path=["../randomfield"]+sys.path
import randomfield as rf
import randomfield.generate as gen
import randomfield.powertools as pt
import randomfield.tests.test_generate as test
import numpy as np
from scipy.interpolate import interp1d
import pylab

g=gen.Generator(nx=128,ny=128,nz=128,grid_spacing_Mpc_h=1.)
delta=g.generate_delta_field(seed=1243)
#lets make a "density field"
delta=2*(1.+delta)
## and now calculate "relative fluctuations"
ks,pk,pke=g.measure_pk(delta,Nk=200, relative=True)
## theory power
theory=g.power
tks=[v[0] for v in theory]
tpk=[v[1] for v in theory]
tpki=interp1d(tks,tpk)
#first calculate chi2:
chi2,n=0,0
for k,p,e in zip(ks,pk,pke):
    if e>0:
        t=tpki(k)
        chi2+=(t-p)**2/e**2
        n+=1
print "Chi2=",chi2,"with dof=",n

pylab.plot(tks,tpk,'r-')
pylab.errorbar(ks,pk,yerr=pke)
pylab.plot(ks,pk,'bo')
pylab.loglog()
pylab.xlim(ks[0]*0.9, ks[-1]*1.1)
pylab.xlabel("k [h/Mpc]")
pylab.ylabel("P(k)")
pylab.show()
```
